### PR TITLE
Fix typos

### DIFF
--- a/apps/blockchain/ethereum/src/Messaging.sol
+++ b/apps/blockchain/ethereum/src/Messaging.sol
@@ -23,7 +23,7 @@ error WithdrawAlreadyError();
  *    In solidity, when we query a mapping, if the key does not exist, 0 is returned when
  *    the value is an uint256.
  *
- *    For this reason, we use here a enum-like to ensure the correct state of the message.
+ *    For this reason, we use here an enum-like to ensure the correct state of the message.
  */
 contract StarklaneMessaging is Ownable {
     // Messages sent directly from L2 indexer, that can be withdrawn with

--- a/apps/indexer/src/handlers/requests.rs
+++ b/apps/indexer/src/handlers/requests.rs
@@ -63,7 +63,7 @@ pub async fn reqs_info_from_wallet(
     Path(wallet): Path<String>,
     state: State<AppState>,
 ) -> Result<Json<Vec<RequestInfo>>, (StatusCode, String)> {
-    let wallet = normalize_hex(&wallet).expect("Wallet address shall be an hexadecimal string");
+    let wallet = normalize_hex(&wallet).expect("Wallet address shall be a hexadecimal string");
 
     let mut dtos: Vec<RequestInfo> = vec![];
 
@@ -97,7 +97,7 @@ pub async fn reqs_info_from_wallet(
 }
 
 pub async fn transaction(Path(txhash): Path<String>, state: State<AppState>) -> StatusCode {
-    let txhash = normalize_hex(&txhash).expect("Transaction hash shall be an hexadecimal string");
+    let txhash = normalize_hex(&txhash).expect("Transaction hash shall be a hexadecimal string");
     if let Ok(event) = state.store.event_by_tx(&txhash).await {
         if event.is_some() {
             return StatusCode::OK;
@@ -124,7 +124,7 @@ pub async fn contract_stats(
     state: State<AppState>,
 ) -> Result<Json<Stats>, (StatusCode, String)> {
     let contract_address = normalize_hex(&eth_contract_address)
-        .expect("Contract address shall be an hexadecimal string");
+        .expect("Contract address shall be a hexadecimal string");
 
     let total_tokens_bridged_on_starknet = state
         .store


### PR DESCRIPTION
This pull request addresses minor typographical errors in the following files:

- Corrected "a enum-like" to "an enum-like" in `Messaging.sol` to comply with grammar rules regarding indefinite articles.
- Fixed repeated phrasing of "hexadecimal string" in `requests.rs` for consistency and clarity.
